### PR TITLE
Add ability to set options for most plugins

### DIFF
--- a/src/main/java/be/ceau/chart/options/Options.java
+++ b/src/main/java/be/ceau/chart/options/Options.java
@@ -46,6 +46,7 @@ public class Options<T extends Options<T>> {
 	private Hover hover;
 	private Animation<?> animation;
 	private Layout layout;
+	private Plugins plugins;
 
 	/**
 	 * @see #setResponsive(Boolean)
@@ -280,6 +281,25 @@ public class Options<T extends Options<T>> {
 	@SuppressWarnings("unchecked")
 	public T setLayout(Layout layout) {
 		this.layout = layout;
+		return (T) this;
+	}
+	
+	/**
+	 * @see #setPlugins(Object)
+	 */
+	public Object getPlugins() {
+		return plugins;
+	}
+
+	/**
+	 * A placeholder in which configuration options for plugins may be passed.
+	 *
+	 * @param plugins {@link Object} or {@code null}
+	 * @return {@code this} instance for chaining
+	 */
+	@SuppressWarnings("unchecked")
+	public T setPlugins(Object plugins) {
+		this.plugins = plugins;
 		return (T) this;
 	}
 

--- a/src/main/java/be/ceau/chart/options/Options.java
+++ b/src/main/java/be/ceau/chart/options/Options.java
@@ -46,7 +46,7 @@ public class Options<T extends Options<T>> {
 	private Hover hover;
 	private Animation<?> animation;
 	private Layout layout;
-	private Plugins plugins;
+	private Object plugins;
 
 	/**
 	 * @see #setResponsive(Boolean)


### PR DESCRIPTION
This simple change will allow you to set configuration options via `options.plugins.*`. Simply pass in a POJO with the desired options into `setPlugins()`.

Not all plugins nest their options under `plugins`, but many of the popular ones do such as:

- [Datalabels](https://github.com/chartjs/chartjs-plugin-datalabels)
- [Stack 100](https://github.com/y-takey/chartjs-plugin-stacked100)
- [Waterfall](https://github.com/everestate/chartjs-plugin-waterfall)

Once this feature is added, I'll publish my repos that extends this project to provide support for the Datalabels plugin, utilizing the new `setPlugins()` hook.

This closes issue #18.