### PR TITLE
Add scaleLabel property to XAxis and YAxis

### DIFF
--- a/src/main/java/be/ceau/chart/options/scales/XAxis.java
+++ b/src/main/java/be/ceau/chart/options/scales/XAxis.java
@@ -87,6 +87,11 @@ public class XAxis<T extends Ticks<T>> {
 	private GridLines gridLines;
 
 	/**
+	 * @see #setScaleLabel(ScaleLabel)
+	 */
+	private ScaleLabel scaleLabel;
+
+	/**
 	 * @see #setTicks(Ticks)
 	 */
 	public T getTicks() {
@@ -240,6 +245,27 @@ public class XAxis<T extends Ticks<T>> {
 	public XAxis<T> setGridLines(GridLines gridLines) {
 		this.gridLines = gridLines;
 		return this;
+	}
+
+	/**
+	 * @see #setScaleLabel(ScaleLabel)
+	 */
+	public ScaleLabel getScaleLabel() {
+		return this.scaleLabel;
+	}
+
+	/**
+	 * <p>
+	 * See scale title configuration section.
+	 * </p>
+	 * 
+	 * <p>
+	 * Default {@code }
+	 * </p>
+	 */
+	public XAxis<T> setScaleLabel(ScaleLabel scaleLabel) {
+		this.scaleLabel = scaleLabel;
+	  return this;
 	}
 
 }

--- a/src/main/java/be/ceau/chart/options/scales/YAxis.java
+++ b/src/main/java/be/ceau/chart/options/scales/YAxis.java
@@ -60,6 +60,11 @@ public class YAxis<T extends Ticks<T>> {
 	private Boolean stacked;
 
 	/**
+	 * @see #setScaleLabel(ScaleLabel)
+	 */
+	private ScaleLabel scaleLabel;
+
+	/**
 	 * @see #setTicks(Ticks)
 	 */
 	public T getTicks() {
@@ -134,4 +139,25 @@ public class YAxis<T extends Ticks<T>> {
 		return this;
 	}
 
+	/**
+	 * @see #setScaleLabel(ScaleLabel)
+	 */
+	public ScaleLabel getScaleLabel() {
+		return this.scaleLabel;
+	}
+
+	/**
+	 * <p>
+	 * See scale title configuration section.
+	 * </p>
+	 * 
+	 * <p>
+	 * Default {@code }
+	 * </p>
+	 */
+	public YAxis<T> setScaleLabel(ScaleLabel scaleLabel) {
+		this.scaleLabel = scaleLabel;
+	  return this;
+	}
+	
 }


### PR DESCRIPTION
This allows cartesian axes to be labeled as described in the official documentation for Chart.js 2.x.x:
https://www.chartjs.org/docs/latest/axes/labelling.html

For simplicity this reuses the existing ScaleLabel class, which is missing the lineHeight and padding properties described in the official documentation.